### PR TITLE
Fixbug when use default port

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -30,12 +30,11 @@ module.exports = function(args){
   var params = [
     '-az',
     'public/',
-    '-e',
     args.user + '@' + args.host + ':' + args.root
   ];
 
   if (args.port && args.port > 0 && args.port < 65536){
-    params.splice(params.length - 1, 0, 'ssh -p ' + args.port);
+    params.splice(params.length - 1, 0, '-e', 'ssh -p ' + args.port);
   }
 
   if (args.verbose) params.unshift('-v');


### PR DESCRIPTION
This bug was introduced in ee0fbbed342825d0bfa36e8b3f65414d79375033

The man page of rsync says:

> -e, --rsh=COMMAND           specify the remote shell to use

`ssh -p 22` is a parameter of options `-e`,  So if no `ssh -p 22`, it should not pass `-e` to rsync.

This commit will resolve #6 