### PR TITLE
Fixing the arguments to rsync so that -e has a remote shell specified

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -32,12 +32,12 @@ module.exports = function(args){
   var params = [
     '-az',
     this.public_dir,
-    '-e',
+    '-e ssh',
     args.user + '@' + args.host + ':' + args.root
   ];
 
   if (args.port && args.port > 0 && args.port < 65536){
-    params.splice(params.length - 1, 0, 'ssh -p ' + args.port);
+    params.splice(params.length - 1, 0, ' -p ' + args.port);
   }
 
   if (args.verbose) params.unshift('-v');


### PR DESCRIPTION
the `-e` option on rsync requires an argument to come after it to specify the remote shell.  In the case where you do not specify a port number, the rsync arguments would not be correct because the `ssh` after the `-e` was moved into the conditional for `args.port`.  The solution is to move `ssh` back into the params array right after the `-e`