### PR TITLE
Non-standard SSH port fix

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -32,12 +32,12 @@ module.exports = function(args){
   var params = [
     '-az',
     this.public_dir,
-    '-e ssh',
     args.user + '@' + args.host + ':' + args.root
   ];
 
   if (args.port && args.port > 0 && args.port < 65536){
-    params.splice(params.length - 1, 0, '--port=' + args.port);
+    params.splice(params.length - 1, 0, '-e');
+    params.splice(params.length - 1, 0, 'ssh -p ' + args.port);
   }
 
   if (args.verbose) params.unshift('-v');

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -24,7 +24,6 @@ module.exports = function(args){
     return;
   }
 
-  if (!args.hasOwnProperty('port')) args.port = 22;
   if (!args.hasOwnProperty('delete')) args.delete = true;
   if (!args.hasOwnProperty('verbose')) args.verbose = true;
   if (!args.hasOwnProperty('ignore_errors')) args.ignore_errors = false;

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -36,8 +36,8 @@ module.exports = function(args){
   ];
 
   if (args.port && args.port > 0 && args.port < 65536){
-    params.splice(params.length - 1, 0, '-e');
-    params.splice(params.length - 1, 0, 'ssh -p ' + args.port);
+    params.splice(params.length - 2, 0, '-e');
+    params.splice(params.length - 2, 0, 'ssh -p ' + args.port);
   }
 
   if (args.verbose) params.unshift('-v');


### PR DESCRIPTION
This fixes the issues introduced by 922adbd1ac23ac8dbdaba05e2b31485378dfb30c and 6c88a8644cea2963b92a95fdf8207441cb2b000f.

1. The `--port` parameter for rsync is NOT the SSH port, it is for the rsync protocol port used when one does not use SSH.
2. Adding `-e` parameter to the rsync command is only needed when a non-default SSH port is specified in the config.