### PR TITLE
chore: require at least Node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "hexo-util": "^0.6.0"
+  },
+  "engines": {
+    "node": ">= 8.6.0"
   }
 }


### PR DESCRIPTION
eslint checks "engines" value to test ES compatibility.