### PR TITLE
Add Support for Using Custom SSH Key

### DIFF
--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -19,6 +19,7 @@ module.exports = function(args) {
     help += '    delete: [true|false] # Default is true\n';
     help += '    args: <rsync args>\n';
     help += '    rsh: <remote shell>\n';
+    help += '    key: <key>\n';
     help += '    verbose: [true|false] # Default is true\n';
     help += '    ignore_errors: [true|false] # Default is false\n\n';
     help += 'For more help, you can check the docs: ' + color.underline('https://hexo.io/docs/deployment.html');
@@ -40,7 +41,13 @@ module.exports = function(args) {
   if (args.port && args.port > 0 && args.port < 65536) {
     params.splice(params.length - 2, 0, '-e');
     if (args.rsh) {
-      params.splice(params.length - 2, 0, `'${args.rsh}' -p ${args.port}`);
+      if (args.key) {
+        params.splice(params.length - 2, 0, `'${args.rsh}' -i ${args.key} -p ${args.port}`);
+      } else {
+        params.splice(params.length - 2, 0, `'${args.rsh}' -p ${args.port}`);
+      }
+    } else if (args.key) {
+      params.splice(params.length - 2, 0, 'ssh -i ' + args.key + ' -p ' + args.port);
     } else {
       params.splice(params.length - 2, 0, 'ssh -p ' + args.port);
     }


### PR DESCRIPTION
Despite it being tedious for some users and possibly unnecessary, for extra security and peace of mind, \
I love having all of my blogs and webapps having separate ssh keys for their deployments. Currently, \
adding a custom key through the args parameter doesn't work properly if the port parameter is set \
in the config, but that's an issue for another day and may or may not be a design choice. Enjoy