### PR TITLE
add option: create non-existing files before updating existing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ deploy:
   rsh: <remote shell>
   verbose: [true|false] # Default is true
   ignore_errors: [true|false] # Default is false
+  create_before_update: [true|false] # Default is false
 ```
 
 - **host**: Address of remote host  
@@ -38,6 +39,7 @@ deploy:
 - **rsh**: Specify the remote shell to use
 - **verbose**: Display verbose messages
 - **ignore_errors**: Ignore errors
+- **create_before_update**: First create non-existing files, then update existing files
 
 ## License
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -20,7 +20,8 @@ module.exports = function(args) {
     help += '    args: <rsync args>\n';
     help += '    rsh: <remote shell>\n';
     help += '    verbose: [true|false] # Default is true\n';
-    help += '    ignore_errors: [true|false] # Default is false\n\n';
+    help += '    ignore_errors: [true|false] # Default is false\n';
+    help += '    create_before_update: [true|false] # Default is false\n\n';
     help += 'For more help, you can check the docs: ' + color.underline('https://hexo.io/docs/deployment.html');
 
     console.log(help);
@@ -30,6 +31,7 @@ module.exports = function(args) {
   if (!Object.prototype.hasOwnProperty.call(args, 'delete')) args.delete = true;
   if (!Object.prototype.hasOwnProperty.call(args, 'verbose')) args.verbose = true;
   if (!Object.prototype.hasOwnProperty.call(args, 'ignore_errors')) args.ignore_errors = false;
+  if (!Object.prototype.hasOwnProperty.call(args, 'create_before_update')) args.create_before_update = false;
 
   const params = [
     '-az',
@@ -51,5 +53,16 @@ module.exports = function(args) {
   if (args.delete) params.unshift('--delete');
   if (args.args) params.unshift(args.args);
 
-  return spawn('rsync', params, {verbose: true});
+  if (args.create_before_update) {
+    // Create non-existing files before updating existing files.
+    // New files may be large documents, images and media, and we want to upload them first before updating links to them in the existing pages.
+    // Otherwise, the links may be updated first and temporarily point to new files that have not been uploaded yet.
+    params.unshift('--ignore-existing');
+    return spawn('rsync', params, {verbose: true}).then(() => {
+      params.shift();
+      return spawn('rsync', params, {verbose: true});
+    });
+  } else {
+    return spawn('rsync', params, {verbose: true});
+  }
 };

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -62,7 +62,6 @@ module.exports = function(args) {
       params.shift();
       return spawn('rsync', params, {verbose: true});
     });
-  } else {
-    return spawn('rsync', params, {verbose: true});
   }
+  return spawn('rsync', params, {verbose: true});
 };


### PR DESCRIPTION
Rsync does not provide atomicity, so, the links in existing pages (e.g., homepage) may be updated before new large files (e.g., images and media) are uploaded, leading to dead links.

This patch introduces a 'create_before_update' option to upload non-existing files before updating links to them in the existing pages.