### PR TITLE
Add support for multiple arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ deploy:
 - **port**: Port
 - **delete**: Delete old files on remote host
 - **progress**: Show rsync progress
-- **args**: Rsync arguments
+- **args**: Rsync arguments (support space-separated strings)
 - **rsh**: Specify the remote shell to use
 - **key**: Custom SSH private key
 - **verbose**: Display verbose messages

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -61,7 +61,7 @@ module.exports = function(args) {
   if (args.ignore_errors) params.unshift('--ignore-errors');
   if (args.delete) params.unshift('--delete');
   if (args.progress) params.unshift('--progress');
-  if (args.args) params.unshift(args.args);
+  if (args.args) params.unshift(...args.args.split(' '));
 
   if (args.create_before_update) {
     // Create non-existing files before updating existing files.


### PR DESCRIPTION
Add support for multiple arguments

## check list

- [x] Add test cases for the changes.
- [x] Passed the CI test.

## Description

This pull request enhances the hexo-deployer-rsync plugin by adding support for multiple arguments. Previously, the args option only allowed a single argument string to be passed to the rsync command. With this update, users can now pass multiple arguments as a space-separated string, which will be correctly split and inserted into the rsync command parameters.

## Example Configuration
```
deploy:
  type: rsync
  host: example.com
  user: admin
  root: /var/www/html/
  port: 22
  delete: true
  progress: false
  args: --chown=admin:root --chmod=D755,F644
  key: /root/.ssh/id_rsa
  verbose: true
  ignore_errors: false
```